### PR TITLE
Allow emission of events with parameters and no target.

### DIFF
--- a/src/ModalComponent.php
+++ b/src/ModalComponent.php
@@ -46,13 +46,13 @@ abstract class ModalComponent extends Component implements Contract
     private function emitModalEvents(array $events): void
     {
         foreach ($events as $component => $event) {
-            if (is_numeric($component)) {
-                $this->emit($event);
-            } else {
-                if (is_array($event)) {
-                    [$event, $params] = $event;
-                }
+            if (is_array($event)) {
+                [$event, $params] = $event;
+            }
 
+            if (is_numeric($component)) {
+                $this->emit($event, ...$params ?? []);
+            } else {
                 $this->emitTo($component, $event, ...$params ?? []);
             }
         }

--- a/tests/LivewireModalComponentTest.php
+++ b/tests/LivewireModalComponentTest.php
@@ -39,9 +39,21 @@ class LivewireModalComponentTest extends TestCase
     {
         Livewire::test(DemoModal::class)
             ->call('closeModalWithEvents', [
+                'someEvent',
+            ])
+            ->assertEmitted('someEvent');
+
+        Livewire::test(DemoModal::class)
+            ->call('closeModalWithEvents', [
                 DemoModal::getName() => 'someEvent',
             ])
             ->assertEmitted('someEvent');
+
+        Livewire::test(DemoModal::class)
+            ->call('closeModalWithEvents', [
+                ['someEventWithParams', ['param1', 'param2']],
+            ])
+            ->assertEmitted('someEventWithParams', 'param1', 'param2');
 
         Livewire::test(DemoModal::class)
             ->call('closeModalWithEvents', [


### PR DESCRIPTION
Currently, you can:

- Emit events without targets or parameters (`->emitModalEvents(['event'])`).
- Emit events with targets and no parameters (`->emitModalEvents(['target' => 'event'])`).
- Emit events with targets and parameters (`->emitModalEvents(['target' => ['event', ['param']]])`).

You can't, however, emit events with parameters but no targets:

`->emitModalEvents([['event', ['param']]])`

This PR makes it possible.