### PR TITLE
Replace ":class" with "x-bind:class" in case Vuejs is also used

### DIFF
--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -34,7 +34,7 @@
             x-transition:leave="ease-in duration-200"
             x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
             x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-            :class="modalWidth"
+            x-bind:class="modalWidth"
             class="inline-block w-full align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:w-full"
         >
             @forelse($components as $id => $component)


### PR DESCRIPTION
If Vuejs is used, then :class colides with Vue. Using x-bind:class allows Alpine to coexist with Vuejs applications.