### PR TITLE
Add Tailwind CSS production build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,39 @@ class DeleteTeam extends ModalComponent
 }
 ```
 
+## Building Tailwind CSS for production
+To purge the classes used by the package, add the following lines to your purge array in `tailwind.config.js`:
+```js
+'./vendor/livewire-ui/modal/resources/views/*.blade.php',
+'./storage/framework/views/*.php',
+```
+
+Because some classes are dynamically build you should add some classes to the purge safelist so your `tailwind.config.js` should look something like this:
+```js
+module.exports = {
+  purge: {
+    content: [
+      './vendor/livewire-ui/modal/resources/views/*.blade.php',
+      './storage/framework/views/*.php',
+      './resources/views/**/*.blade.php',
+    ],
+    options: {
+      safelist: [
+        'sm:max-w-2xl'
+      ]
+    }
+  },
+  darkMode: false, // or 'media' or 'class'
+  theme: {
+    extend: {},
+  },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
+}
+```
+
 ## Security
 If you are new to Livewire I recommend to take a look at the [security details](https://laravel-livewire.com/docs/2.x/security). In short, it's **very important** to validate all information given Livewire stores this information on the client-side, or in other words, this data can be manipulated. Like shown in the examples above, use the `Guard` facade to authorize actions.
 


### PR DESCRIPTION
I opened the issue #37 and @PhiloNL came to the conclusion that some classes are dynamically generated to it should be in the blade files for purging.

I went to the Tailwind CSS documentation for the instructions for a safelist. I don't know the exact classes this package could be generating, but I have already added the class that was the bug of my issue.