### PR TITLE
Component defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,9 @@ module.exports = {
 ```
 
 ## Configuration
-You can customize the Modal via the `livewire-ui-modal.php` config file. This includes some additional options like including CSS if you don't use TailwindCSS for your application. To publish the config run the vendor:publish command:
+You can customize the Modal via the `livewire-ui-modal.php` config file. This includes some additional options like including CSS if you don't use TailwindCSS for your application, as well as the default modal properties.
+
+ To publish the config run the vendor:publish command:
 ```shell
 php artisan vendor:publish --tag=livewire-ui-modal-config
 ```
@@ -379,6 +381,28 @@ return [
     */
     'include_js' => true,
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Modal Component Defaults
+    |--------------------------------------------------------------------------
+    |
+    | Configure the default properties for a modal component.
+    | 
+    | Supported modal_max_width
+    | 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl'
+    */
+    'component_defaults' => [
+        'modal_max_width' => '2xl',
+        
+        'close_modal_on_click_away' => true,
+
+        'close_modal_on_escape' => true,
+
+        'close_modal_on_escape_is_forceful' => true,
+
+        'dispatch_close_event' => false,
+    ],
 ];
 ```
 

--- a/config/livewire-ui-modal.php
+++ b/config/livewire-ui-modal.php
@@ -27,4 +27,29 @@ return [
     */
     'include_js' => true,
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Modal Component Defaults
+    |--------------------------------------------------------------------------
+    |
+    | Configure the default properties for a modal component.
+    |
+    | modal_max_width: 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl'
+    | close_modal_on_click_away: bool
+    | close_modal_on_escape: bool
+    | close_modal_on_escape_is_forceful: bool
+    | dispatch_close_event: bool
+    */
+    'component_defaults' => [
+        'modal_max_width' => '2xl',
+        
+        'close_modal_on_click_away' => true,
+
+        'close_modal_on_escape' => true,
+
+        'close_modal_on_escape_is_forceful' => true,
+
+        'dispatch_close_event' => false,
+    ],
 ];

--- a/config/livewire-ui-modal.php
+++ b/config/livewire-ui-modal.php
@@ -34,12 +34,9 @@ return [
     |--------------------------------------------------------------------------
     |
     | Configure the default properties for a modal component.
-    |
-    | modal_max_width: 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl'
-    | close_modal_on_click_away: bool
-    | close_modal_on_escape: bool
-    | close_modal_on_escape_is_forceful: bool
-    | dispatch_close_event: bool
+    | 
+    | Supported modal_max_width
+    | 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl'
     */
     'component_defaults' => [
         'modal_max_width' => '2xl',

--- a/src/ModalComponent.php
+++ b/src/ModalComponent.php
@@ -45,27 +45,27 @@ abstract class ModalComponent extends Component implements Contract
 
     public static function modalMaxWidth(): string
     {
-        return '2xl';
+        return config('livewire-ui-modal.component_defaults.modal_max_width', '2xl');
     }
 
     public static function closeModalOnClickAway(): bool
     {
-        return true;
+        return config('livewire-ui-modal.component_defaults.close_modal_on_click_away', true);
     }
 
     public static function closeModalOnEscape(): bool
     {
-        return true;
+        return config('livewire-ui-modal.component_defaults.close_modal_on_escape', true);
     }
 
     public static function closeModalOnEscapeIsForceful(): bool
     {
-        return true;
+        return config('livewire-ui-modal.component_defaults.close_modal_on_escape_is_forceful', true);
     }
 
     public static function dispatchCloseEvent(): bool
     {
-        return false;
+        return config('livewire-ui-modal.component_defaults.dispatch_close_event', true);
     }
 
     private function emitModalEvents(array $events): void

--- a/src/ModalComponent.php
+++ b/src/ModalComponent.php
@@ -65,7 +65,7 @@ abstract class ModalComponent extends Component implements Contract
 
     public static function dispatchCloseEvent(): bool
     {
-        return config('livewire-ui-modal.component_defaults.dispatch_close_event', true);
+        return config('livewire-ui-modal.component_defaults.dispatch_close_event', false);
     }
 
     private function emitModalEvents(array $events): void


### PR DESCRIPTION
PR to allow the user to specify defaults for the following modal properties in the livewire-ui-modal config file.

- modalMaxWidth
- closeModalOnClickAway
- closeModalOnEscape
- closeModalOnEscapeIsForceful
- dispatchCloseEvent

I found I was always overriding the methods on my modal components and this will allow to set different defaults and only override when required.