### PR TITLE
Update README to include example when using non-default user IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To open the `EditUser` modal for a specific user we can pass the user id (notice
 <!-- Inside existing Livewire component -->
 <button wire:click='$emit("openModal", "edit-user", {{ json_encode(["user" => $user->id]) }})'>Edit User</button>
 
-<!-- If you have use a different primaryKey (e.g. email), adjust accordingly -->
+<!-- If you use a different primaryKey (e.g. email), adjust accordingly -->
 <button wire:click='$emit("openModal", "edit-user", {{ json_encode(["user" => $user->email]) }})'>Edit User</button>
 
 <!-- Example of passing multiple parameters -->

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ To open the `EditUser` modal for a specific user we can pass the user id (notice
 <!-- Inside existing Livewire component -->
 <button wire:click='$emit("openModal", "edit-user", {{ json_encode(["user" => $user->id]) }})'>Edit User</button>
 
+<!-- If you have use a different primaryKey (e.g. email), adjust accordingly -->
+<button wire:click='$emit("openModal", "edit-user", {{ json_encode(["user" => $user->email]) }})'>Edit User</button>
+
 <!-- Example of passing multiple parameters -->
 <button wire:click='$emit("openModal", "edit-user", {{ json_encode([$user->id, $isAdmin]) }})'>Edit User</button>
-
-<!-- Passing the user id if you have implemented getRouteKeyName() in your model -->
-<button onclick='Livewire.emit("openModal", "edit-user", {{ json_encode(["user" => $user->slug]) }})'>Edit User</button>
 ```
 
 The parameters are passed to the `mount` method on the modal component:

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ To open the `EditUser` modal for a specific user we can pass the user id (notice
 
 <!-- Example of passing multiple parameters -->
 <button wire:click='$emit("openModal", "edit-user", {{ json_encode([$user->id, $isAdmin]) }})'>Edit User</button>
+
+<!-- Passing the user id if you have implemented getRouteKeyName() in your model -->
+<button onclick='Livewire.emit("openModal", "edit-user", {{ json_encode(["user" => $user->slug]) }})'>Edit User</button>
 ```
 
 The parameters are passed to the `mount` method on the modal component:


### PR DESCRIPTION
After a sleepless night I figured out why my application that uses Spatie's sluggable for usernames wasn't working and thought it an idea to include an example in the README file.